### PR TITLE
Debug app.py error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ google-generativeai>=0.3.0
 pandas>=1.5.0
 numpy>=1.24.0
 plotly
-datetime

--- a/streamlit.log
+++ b/streamlit.log
@@ -1,0 +1,5 @@
+
+  You can now view your Streamlit app in your browser.
+
+  URL: http://0.0.0.0:8501
+


### PR DESCRIPTION
Remove `datetime` from `requirements.txt` to resolve dependency resolution issues and allow the Streamlit app to run.

`datetime` is a Python standard library module and should not be listed in `requirements.txt`. Its presence caused `pip` to fail during dependency installation, preventing the application from starting.

---
<a href="https://cursor.com/background-agent?bcId=bc-9728fe0a-19a8-4fda-aa6c-e6843bbea709">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9728fe0a-19a8-4fda-aa6c-e6843bbea709">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

